### PR TITLE
Adjust line 52.

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -49,7 +49,7 @@
 {{ "<!-- Non Critical CSS -->" | safeHTML }}
 {{$style :=  resources.Get "scss/non-critical.scss" | resources.ToCSS | resources.Minify }}
 <link href="{{ $style.Permalink }}" rel="stylesheet" />
-<script src="https://maps.googleapis.com/maps/api/js?key={{ .Site.Params.APIkey }}&libraries=geometry">
+<script src="https://maps.googleapis.com/maps/api/js?key={{ .Site.Params.Map.APIkey }}&libraries=geometry">
 </script>
 {{ "<!-- VENDOR JS -->" | safeHTML }}
 <script src="{{"vendor/jQuery/jquery.min.js" | absURL }}"></script>


### PR DESCRIPTION
If you add your Google Maps API key in config.toml it will not work unless you move the APIkey section under [params]. Does not work under [params.Map] by default.