### PR TITLE
deleted the extra menu that broke the menu

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,7 +4,7 @@ paginate = 6
 theme= "coHub"
 title = 'coHub'
  
-[Menu]
+
   # Main Menu
   [[menu.Main]]
   name = "Exhibition"


### PR DESCRIPTION
The extra menu in the example site at line 7 creates issues for the header partial at line 21 so i deleted it.