### PR TITLE
Added config rename CLI req

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check out the live demo [here](https://cohub-hugo.netlify.app/)
 
    ```cli
    cp -a themes/coHub/exampleSite/* .
+   mv config.toml hugo.toml
    ```
 
 3. Build your site with `hugo serve` and see the result at `http://localhost:1313/`.


### PR DESCRIPTION
Before this change the menu items were missing from the rendering of the site.

This change uses the theme config.toml file and overwrites the settings my renaming the file from `config.toml` to `hugo.toml` in the root of the project.

Fixes #7 